### PR TITLE
Replace :environment with :remote_environment

### DIFF
--- a/lib/mina/rpush/tasks.rb
+++ b/lib/mina/rpush/tasks.rb
@@ -4,31 +4,31 @@ namespace :rpush do
   set :rpush_command, -> { "cd #{fetch(:current_path)} && #{fetch(:bundle_prefix)} rpush" }
 
   desc 'Start rpush'
-  task start: :environment do
+  task start: :remote_environment do
     command %[echo '-----> Starting rpush']
     command "#{fetch(:rpush_command)} start -e #{fetch(:rails_env)}"
   end
 
   desc 'Stop rpush'
-  task stop: :environment do
+  task stop: :remote_environment do
     command %[echo '-----> Stopping rpush']
     command "#{fetch(:rpush_command)} stop -e #{fetch(:rails_env)}"
   end
 
   desc 'Restart rpush'
-  task restart: :environment do
+  task restart: :remote_environment do
     command %[echo '-----> Restarting rpush']
     command "#{fetch(:rpush_command)} stop -e #{fetch(:rails_env)}; #{fetch(:rpush_command)} start -e #{fetch(:rails_env)}"
   end
 
   desc 'Push pending notifications'
-  task push: :environment do
+  task push: :remote_environment do
     command %[echo '-----> Pushing pending notifications']
     command "#{fetch(:rpush_command)} push -e #{fetch(:rails_env)}"
   end
 
   desc 'Check rpush status'
-  task status: :environment do
+  task status: :remote_environment do
     command %[echo '-----> Checking rpush status']
     command "#{fetch(:rpush_command)} status -e #{fetch(:rails_env)}"
   end


### PR DESCRIPTION
@d4rky-pl hello!

Thanks for your work on this gem.

I've started to receive some deprecation warnings from mina and noted that mina-rpush require a minor update to work with the latest versions of mina according to the  
[mina-deploy/mina/tasks/mina/default.rb](
 https://github.com/mina-deploy/mina/blob/a1865e1c08d8394241b210f04ce27586d1afcc01/tasks/mina/default.rb#L6) updates.

Please let me know what do you think on it.